### PR TITLE
update service name to match other repos

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,12 +12,12 @@ networks:
         - subnet: 10.0.0.0/24
 
 services:
-  identity-service:
+  protocol-identity-service:
     build:
       context: .
       dockerfile: Dockerfile.identityservice
-    image: identity-service
-    container_name: identity-service
+    image: protocol-identity-service
+    container_name: protocol-identity-service
     ports:
       - "8081:8080"
     env_file:
@@ -71,5 +71,5 @@ services:
     networks:
       - agency-network
     depends_on:
-      - identity-service
+      - protocol-identity-service
     tty: true


### PR DESCRIPTION
There are a few places where we use the docker container name in order to make an http call, eg https://github.com/kiva/aries-key-guardian/blob/master/src/config/env.json#L22
So we'd either need to change it there or change it here, and it seemed easier to change it here
Signed-off-by: Jacob Saur <jsaur@kiva.org>