### PR TITLE
Remove unnecessary update script.

### DIFF
--- a/identity_template_db/update-scripts/2020-4-14-add-quality-score.sql
+++ b/identity_template_db/update-scripts/2020-4-14-add-quality-score.sql
@@ -1,1 +1,0 @@
-ALTER TABLE kiva_biometric_template ADD COLUMN quality_score INTEGER;


### PR DESCRIPTION
This update script is supposed to add a column to a table that already has that column. Presumably there was some time in which the column wasn't already there, but it's redundant and confusing now.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>