### PR TITLE
PRO-2460 (Bugfix): Should store template if bioanalyzer is disabled

### DIFF
--- a/identity_service/src/main/kotlin/org/kiva/identityservice/services/BioAnalyzer.kt
+++ b/identity_service/src/main/kotlin/org/kiva/identityservice/services/BioAnalyzer.kt
@@ -41,9 +41,9 @@ class BioAnalyzer(
 
                 val reqId = MDC.get(REQUEST_ID)
 
-                val bioAnalyserHost = System.getenv("BIOANALYZER_SERVICE_URL")
+                val bioAnalyzerHost = System.getenv("BIOANALYZER_SERVICE_URL")
 
-                return WebClient.create(bioAnalyserHost)
+                return WebClient.create(bioAnalyzerHost)
                     .post()
                     .uri(ANALYZE_URL)
                     .accept(MediaType.APPLICATION_JSON)
@@ -56,7 +56,7 @@ class BioAnalyzer(
                     }
                     .flatMap { handleAnalyzerResponse(reqId, throwException, it) }
             } else {
-                return Mono.empty()
+                return Mono.just(0.0)
             }
         } catch (e: Exception) {
             /**

--- a/identity_service/src/main/kotlin/org/kiva/identityservice/services/backends/drivers/TemplateBackend.kt
+++ b/identity_service/src/main/kotlin/org/kiva/identityservice/services/backends/drivers/TemplateBackend.kt
@@ -108,9 +108,13 @@ class TemplateBackend : ReactivePostgresSqlBackend(), IHasTemplateSupport {
     }
 
     override fun templateGenerate(records: Flux<Fingerprint>, throwException: Boolean, sdk: IBiometricSDKAdapter, bioAnalyzer: IBioAnalyzer): Flux<Int> {
-        return records.flatMap { it.image?.let { image -> findFingerprintScore(image, throwException, bioAnalyzer) }
-            ?.flatMap { score -> this.templateGenerateHelper(it, score, sdk) }
-            ?: this.templateGenerateHelper(it, 0.0, sdk) }
+        return records
+            .flatMap { fingerprint ->
+                fingerprint.image
+                    ?.let { image -> findFingerprintScore(image, throwException, bioAnalyzer) }
+                    ?.flatMap { score -> this.templateGenerateHelper(fingerprint, score, sdk) }
+                    ?: this.templateGenerateHelper(fingerprint, 0.0, sdk)
+            }
     }
 
     override fun storeTemplate(sdk: IBiometricSDKAdapter, storeRequest: StoreRequest): Mono<FingerprintTemplate> {


### PR DESCRIPTION
If bioanalyzer is disabled, return a score of 0.0 instead of null (which is what Mono.empty() returns).

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>