### PR TITLE
Need to use Java 11 when publishing docker images too.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,8 @@ workflows:
             branches:
               ignore: /.*/
           after_checkout:
+            - openjdk-install/openjdk:
+                version: 11
             - run:
                 name: build bioanalyzer service
                 command: |
@@ -72,6 +74,8 @@ workflows:
             branches:
               ignore: /.*/
           after_checkout:
+            - openjdk-install/openjdk:
+                version: 11
             - run:
                 name: build identity service
                 command: |


### PR DESCRIPTION
Need to use Java 11 when publishing docker images too.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>