### PR TITLE
Provide error message in identity service.

### DIFF
--- a/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/GlobalErrorAttributes.kt
+++ b/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/GlobalErrorAttributes.kt
@@ -14,6 +14,7 @@ class GlobalErrorAttributes : DefaultErrorAttributes() {
         val error = getError(request)
         if (error is ApiException) {
             map["code"] = error.code.name
+            map["message"] = error.reason
         }
         return map
     }


### PR DESCRIPTION
Error responses from identity service should include the error message if a reason is provided.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>