### PR TITLE
Increase spring codec size so as to be able to handle larger requests

### DIFF
--- a/identity_service/src/main/resources/application.properties
+++ b/identity_service/src/main/resources/application.properties
@@ -1,6 +1,8 @@
 logging.level.org.springframework.web=INFO
 logging.level.org.kiva.identityservice=DEBUG
 
+spring.codec.max-in-memory-size=5MB
+
 namkha.sourceafis.match_threshold=40.0
 namkha.valid_image_types=image/jpeg,image/jpg,image/png,image/bmp,image/wsq
 namkha.minimum_quality_threshold=40.0

--- a/identity_service/src/test/resources/application.properties
+++ b/identity_service/src/test/resources/application.properties
@@ -6,3 +6,5 @@ namkha.backend.fetch_limit=1000
 namkha.templatizer.cron=0 0/15 0-8 ? * * *
 namkha.templatizer.processors=0
 namkha.templatizer.batchSize=1000
+
+spring.codec.max-in-memory-size=5MB


### PR DESCRIPTION
Increase spring codec size so as to be able to handle larger requests - i.e. those containing images. Same treatment as was required for the Bioanalyzer Service.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>