### PR TITLE
PRO-2696: Match error code style with the rest of the system

### DIFF
--- a/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/BioanalyzerServiceException.kt
+++ b/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/BioanalyzerServiceException.kt
@@ -7,4 +7,4 @@ import org.springframework.http.HttpStatus
 /**
  * The exception class thrown when there is an error in the bioanalyzer service call.
  */
-class BioanalyzerServiceException(reason: String? = null) : ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.BIOANALYZER_SERVER_ERROR, reason)
+class BioanalyzerServiceException(reason: String? = null) : ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.BioanalyzerServerError, reason)

--- a/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/InvalidBackendOperationException.kt
+++ b/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/InvalidBackendOperationException.kt
@@ -10,6 +10,6 @@ import org.springframework.http.HttpStatus
 class InvalidBackendOperationException(
     private val backend: String,
     private val operation: String
-) : ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.INVALID_BACKEND_OPERATION) {
+) : ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.InvalidBackendOperation) {
     override fun toString(): String = "Backend [$backend] does not support operation: $operation"
 }

--- a/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/InvalidParamsException.kt
+++ b/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/InvalidParamsException.kt
@@ -3,4 +3,4 @@ package org.kiva.identityservice.errorhandling.exceptions
 import org.kiva.identityservice.errorhandling.exceptions.api.ApiExceptionCode
 import org.kiva.identityservice.errorhandling.exceptions.api.ValidationError
 
-class InvalidParamsException(reason: String? = null) : ValidationError(ApiExceptionCode.INVALID_PARAMS, reason)
+class InvalidParamsException(reason: String? = null) : ValidationError(ApiExceptionCode.InvalidParams, reason)

--- a/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/ApiExceptionCode.kt
+++ b/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/ApiExceptionCode.kt
@@ -1,20 +1,20 @@
 package org.kiva.identityservice.errorhandling.exceptions.api
 
 enum class ApiExceptionCode constructor(val msg: String) {
-    NO_CITIZEN_FOUND("No citizen found for specified filters"),
-    FINGERPRINT_NO_MATCH("Fingerprint did not match stored records for citizen supplied through filters"),
-    FINGERPRINT_LOW_QUALITY("Given fingerprint is of too low quality to be used for matching. Please recapture"),
-    FINGERPRINT_MISSING_NOT_CAPTURED("There is no fingerprint for supplied position stored in the database for matching citizen, it was not captured"),
-    FINGERPRINT_MISSING_AMPUTATION("There is no fingerprint stored in the database, due to amputation"), // @TODO
-    FINGERPRINT_MISSING_UNABLE_TO_PRINT("There is no fingerprint stored in the database, unable to record fingerprint"), // @TODO
-    INVALID_FILTERS("One of your filters is invalid or missing"),
-    INVALID_PARAMS("One of your params is invalid or missing"),
-    INVALID_IMAGE_ENCODING("Invalid image encoding, must be base64 encoded"),
-    INVALID_IMAGE_FORMAT("Invalid image format, must be one of ..."),
-    INVALID_POSITION("Invalid position, must be one of ..."),
-    INVALID_DATA_TYPE("The data type is not supported for the backend"),
-    INVALID_TEMPLATE_VERSION("Invalid template version"),
-    INVALID_BACKEND_NAME("Invalid backend name"),
-    INVALID_BACKEND_OPERATION("Invalid backend operation"),
-    BIOANALYZER_SERVER_ERROR("Bioanalyzer server error")
+    NoCitizenFound("No citizen found for specified filters"),
+    FingerprintNoMatch("Fingerprint did not match stored records for citizen supplied through filters"),
+    FingerprintLowQuality("Given fingerprint is of too low quality to be used for matching. Please recapture"),
+    FingerprintMissingNotCaptured("There is no fingerprint for supplied position stored in the database for matching citizen, it was not captured"),
+    FingerprintMissingAmputation("There is no fingerprint stored in the database, due to amputation"), // @TODO
+    FingerprintMissingUnableToPrint("There is no fingerprint stored in the database, unable to record fingerprint"), // @TODO
+    InvalidFilters("One of your filters is invalid or missing"),
+    InvalidParams("One of your params is invalid or missing"),
+    InvalidImageEncoding("Invalid image encoding, must be base64 encoded"),
+    InvalidImageFormat("Invalid image format, must be one of ..."),
+    InvalidPosition("Invalid position, must be one of ..."),
+    InvalidDataType("The data type is not supported for the backend"),
+    InvalidTemplateVersion("Invalid template version"),
+    InvalidBackendName("Invalid backend name"),
+    InvalidBackendOperation("Invalid backend operation"),
+    BioanalyzerServerError("Bioanalyzer server error");
 }

--- a/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/FingerprintLowQualityException.kt
+++ b/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/FingerprintLowQualityException.kt
@@ -2,4 +2,4 @@ package org.kiva.identityservice.errorhandling.exceptions.api
 
 import org.springframework.http.HttpStatus
 
-class FingerprintLowQualityException(reason: String) : ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.FINGERPRINT_LOW_QUALITY, reason)
+class FingerprintLowQualityException(reason: String) : ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.FingerprintLowQuality, reason)

--- a/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/FingerprintMissingAmputationException.kt
+++ b/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/FingerprintMissingAmputationException.kt
@@ -2,4 +2,4 @@ package org.kiva.identityservice.errorhandling.exceptions.api
 
 import org.springframework.http.HttpStatus
 
-class FingerprintMissingAmputationException() : ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.FINGERPRINT_MISSING_AMPUTATION)
+class FingerprintMissingAmputationException() : ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.FingerprintMissingAmputation)

--- a/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/FingerprintMissingNotCapturedException.kt
+++ b/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/FingerprintMissingNotCapturedException.kt
@@ -2,4 +2,4 @@ package org.kiva.identityservice.errorhandling.exceptions.api
 
 import org.springframework.http.HttpStatus
 
-class FingerprintMissingNotCapturedException() : ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.FINGERPRINT_MISSING_NOT_CAPTURED)
+class FingerprintMissingNotCapturedException() : ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.FingerprintMissingNotCaptured)

--- a/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/FingerprintMissingUnableToPrintException.kt
+++ b/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/FingerprintMissingUnableToPrintException.kt
@@ -2,4 +2,4 @@ package org.kiva.identityservice.errorhandling.exceptions.api
 
 import org.springframework.http.HttpStatus
 
-class FingerprintMissingUnableToPrintException() : ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.FINGERPRINT_MISSING_UNABLE_TO_PRINT)
+class FingerprintMissingUnableToPrintException() : ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.FingerprintMissingUnableToPrint)

--- a/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/FingerprintNoMatchException.kt
+++ b/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/FingerprintNoMatchException.kt
@@ -2,4 +2,4 @@ package org.kiva.identityservice.errorhandling.exceptions.api
 
 import org.springframework.http.HttpStatus
 
-class FingerprintNoMatchException(reason: String? = null) : ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.FINGERPRINT_NO_MATCH, reason)
+class FingerprintNoMatchException(reason: String? = null) : ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.FingerprintNoMatch, reason)

--- a/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/InvalidFilterException.kt
+++ b/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/InvalidFilterException.kt
@@ -1,3 +1,3 @@
 package org.kiva.identityservice.errorhandling.exceptions.api
 
-class InvalidFilterException(reason: String? = null) : ValidationError(ApiExceptionCode.INVALID_FILTERS, reason)
+class InvalidFilterException(reason: String? = null) : ValidationError(ApiExceptionCode.InvalidFilters, reason)

--- a/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/InvalidFingerPositionException.kt
+++ b/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/InvalidFingerPositionException.kt
@@ -1,3 +1,3 @@
 package org.kiva.identityservice.errorhandling.exceptions.api
 
-class InvalidFingerPositionException(reason: String? = null) : ValidationError(ApiExceptionCode.INVALID_POSITION, reason)
+class InvalidFingerPositionException(reason: String? = null) : ValidationError(ApiExceptionCode.InvalidPosition, reason)

--- a/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/InvalidImageFormatException.kt
+++ b/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/InvalidImageFormatException.kt
@@ -2,4 +2,4 @@ package org.kiva.identityservice.errorhandling.exceptions.api
 
 import org.springframework.http.HttpStatus
 
-class InvalidImageFormatException(reason: String) : ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.INVALID_IMAGE_FORMAT, reason)
+class InvalidImageFormatException(reason: String) : ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.InvalidImageFormat, reason)

--- a/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/NoCitizenFoundException.kt
+++ b/identity_service/src/main/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/NoCitizenFoundException.kt
@@ -2,4 +2,4 @@ package org.kiva.identityservice.errorhandling.exceptions.api
 
 import org.springframework.http.HttpStatus
 
-class NoCitizenFoundException(reason: String? = null) : ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.NO_CITIZEN_FOUND, reason)
+class NoCitizenFoundException(reason: String? = null) : ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.NoCitizenFound, reason)

--- a/identity_service/src/main/kotlin/org/kiva/identityservice/services/VerificationEngine.kt
+++ b/identity_service/src/main/kotlin/org/kiva/identityservice/services/VerificationEngine.kt
@@ -51,14 +51,14 @@ class VerificationEngine(
                 }
 
                 if (!validImageTypes.contains(contentType)) {
-                    val e = InvalidImageFormatException(ApiExceptionCode.INVALID_IMAGE_FORMAT.msg)
+                    val e = InvalidImageFormatException(ApiExceptionCode.InvalidImageFormat.msg)
                     logErrorMessage(e)
                     return Mono.error(e)
                 }
             } else if (verifyRequest.imageType == DataType.TEMPLATE) {
                 // For template image queries, the image field should be plain text of json template.
                 if (contentType != PLAIN_TEXT_CONTENT_TYPE) {
-                    val e = InvalidImageFormatException(ApiExceptionCode.INVALID_IMAGE_FORMAT.msg)
+                    val e = InvalidImageFormatException(ApiExceptionCode.InvalidImageFormat.msg)
                     logErrorMessage(e)
                     return Mono.error(e)
                 }
@@ -136,21 +136,21 @@ class VerificationEngine(
      */
     private fun logErrorMessage(error: Throwable?) {
         if (error is NoCitizenFoundException) {
-            logger.warn(ApiExceptionCode.NO_CITIZEN_FOUND.msg, error)
+            logger.warn(ApiExceptionCode.NoCitizenFound.msg, error)
         } else if (error is FingerprintMissingNotCapturedException) {
-            logger.warn(ApiExceptionCode.FINGERPRINT_MISSING_NOT_CAPTURED.msg, error)
+            logger.warn(ApiExceptionCode.FingerprintMissingNotCaptured.msg, error)
         } else if (error is FingerprintNoMatchException) {
-            logger.warn(ApiExceptionCode.FINGERPRINT_NO_MATCH.msg, error)
+            logger.warn(ApiExceptionCode.FingerprintNoMatch.msg, error)
         } else if (error is InvalidBackendException) {
-            logger.error(ApiExceptionCode.INVALID_BACKEND_NAME.msg, error)
+            logger.error(ApiExceptionCode.InvalidBackendName.msg, error)
         } else if (error is FingerprintLowQualityException) {
-            logger.warn(ApiExceptionCode.FINGERPRINT_LOW_QUALITY.msg, error)
+            logger.warn(ApiExceptionCode.FingerprintLowQuality.msg, error)
         } else if (error is InvalidFilterException) {
-            logger.warn(ApiExceptionCode.INVALID_FILTERS.msg, error)
+            logger.warn(ApiExceptionCode.InvalidFilters.msg, error)
         } else if (error is FingerPrintTemplateException) {
-            logger.error(ApiExceptionCode.INVALID_TEMPLATE_VERSION.msg, error)
+            logger.error(ApiExceptionCode.InvalidTemplateVersion.msg, error)
         } else if (error is InvalidImageFormatException) {
-            logger.error(ApiExceptionCode.INVALID_IMAGE_FORMAT.msg, error)
+            logger.error(ApiExceptionCode.InvalidImageFormat.msg, error)
         } else if (error is TimeoutException) {
             logger.error(BIOANALYZER_TIMEOUT_MESSAGE, error)
         } else {

--- a/identity_service/src/main/kotlin/org/kiva/identityservice/services/backends/drivers/TemplateBackend.kt
+++ b/identity_service/src/main/kotlin/org/kiva/identityservice/services/backends/drivers/TemplateBackend.kt
@@ -88,7 +88,7 @@ class TemplateBackend(private val env: EnvConfig) :
             q.addConditions(condition("template_type = ?", sdk.templateType))
             q.addConditions(condition("type_id = ?", 1))
         } else {
-            throw ValidationError(ApiExceptionCode.INVALID_DATA_TYPE, "Image data type is not supported for template backend.")
+            throw ValidationError(ApiExceptionCode.InvalidDataType, "Image data type is not supported for template backend.")
         }
         return q
     }
@@ -114,7 +114,7 @@ class TemplateBackend(private val env: EnvConfig) :
         val type = DataType.valueOf(row["image_type", String::class.java]!!)
         val imageBytes = when (type) {
             DataType.TEMPLATE -> rawImage.toByteArray(Charsets.UTF_8)
-            else -> throw ValidationError(ApiExceptionCode.INVALID_DATA_TYPE, "Image data type is not supported for template backend.")
+            else -> throw ValidationError(ApiExceptionCode.InvalidDataType, "Image data type is not supported for template backend.")
         }
         return Identity(did, nationalId!!, mapOf(verifyRequest.params.position to imageBytes), type, templateVersion)
     }

--- a/identity_service/src/main/kotlin/org/kiva/identityservice/services/sdks/sourceafis/SourceAFISFingerprintSDKAdapter.kt
+++ b/identity_service/src/main/kotlin/org/kiva/identityservice/services/sdks/sourceafis/SourceAFISFingerprintSDKAdapter.kt
@@ -61,7 +61,7 @@ class SourceAFISFingerprintSDKAdapter(
                             // we check for exact equality here; other SDKs are free to check for version range
                             it.templateVersion?.let { check ->
                                 if (check != version)
-                                    throw FingerPrintTemplateException(ApiExceptionCode.INVALID_TEMPLATE_VERSION.msg)
+                                    throw FingerPrintTemplateException(ApiExceptionCode.InvalidTemplateVersion.msg)
                             }
                             FingerprintTemplate().deserialize(String(it.fingerprints[verifyRequest.params.position]!!, Charsets.UTF_8))
                         }

--- a/identity_service/src/test/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/ApiExceptionCodeTest.kt
+++ b/identity_service/src/test/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/ApiExceptionCodeTest.kt
@@ -1,6 +1,7 @@
 package org.kiva.identityservice.errorhandling.exceptions.api
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 
 /**
@@ -8,28 +9,112 @@ import org.junit.jupiter.api.Test
  */
 class ApiExceptionCodeTest {
 
+    private fun testNoCitizenFound(code: ApiExceptionCode) {
+        val expectedMsg = "No citizen found for specified filters"
+        assertEquals(expectedMsg, code.msg, "Mismatch in message")
+    }
+
+    private fun testFingerprintNoMatch(code: ApiExceptionCode) {
+        val expectedMsg = "Fingerprint did not match stored records for citizen supplied through filters"
+        assertEquals(expectedMsg, code.msg, "Mismatch in message")
+    }
+
+    private fun testFingerprintLowQuality(code: ApiExceptionCode) {
+        val expectedMsg = "Given fingerprint is of too low quality to be used for matching. Please recapture"
+        assertEquals(expectedMsg, code.msg, "Mismatch in message")
+    }
+
+    private fun testFingerprintMissingNotCaptured(code: ApiExceptionCode) {
+        val expectedMsg = "There is no fingerprint for supplied position stored in the database for matching citizen, it was not captured"
+        assertEquals(expectedMsg, code.msg, "Mismatch in message")
+    }
+
+    private fun testFingerprintMissingAmputation(code: ApiExceptionCode) {
+        val expectedMsg = "There is no fingerprint stored in the database, due to amputation"
+        assertEquals(expectedMsg, code.msg, "Mismatch in message")
+    }
+
+    private fun testFingerprintMissingUnableToPrint(code: ApiExceptionCode) {
+        val expectedMsg = "There is no fingerprint stored in the database, unable to record fingerprint"
+        assertEquals(expectedMsg, code.msg, "Mismatch in message")
+    }
+
+    private fun testInvalidFilters(code: ApiExceptionCode) {
+        val expectedMsg = "One of your filters is invalid or missing"
+        assertEquals(expectedMsg, code.msg, "Mismatch in message")
+    }
+
+    private fun testInvalidParams(code: ApiExceptionCode) {
+        val expectedMsg = "One of your params is invalid or missing"
+        assertEquals(expectedMsg, code.msg, "Mismatch in message")
+    }
+
+    private fun testInvalidImageEncoding(code: ApiExceptionCode) {
+        val expectedMsg = "Invalid image encoding, must be base64 encoded"
+        assertEquals(expectedMsg, code.msg, "Mismatch in message")
+    }
+
+    private fun testInvalidImageFormat(code: ApiExceptionCode) {
+        val expectedMsg = "Invalid image format, must be one of ..."
+        assertEquals(expectedMsg, code.msg, "Mismatch in message")
+    }
+
+    private fun testInvalidPosition(code: ApiExceptionCode) {
+        val expectedMsg = "Invalid position, must be one of ..."
+        assertEquals(expectedMsg, code.msg, "Mismatch in message")
+    }
+
+    private fun testInvalidDataType(code: ApiExceptionCode) {
+        val expectedMsg = "The data type is not supported for the backend"
+        assertEquals(expectedMsg, code.msg, "Mismatch in message")
+    }
+
+    private fun testInvalidTemplateVersion(code: ApiExceptionCode) {
+        val expectedMsg = "Invalid template version"
+        assertEquals(expectedMsg, code.msg, "Mismatch in message")
+    }
+
+    private fun testInvalidBackendName(code: ApiExceptionCode) {
+        val expectedMsg = "Invalid backend name"
+        assertEquals(expectedMsg, code.msg, "Mismatch in message")
+    }
+
+    private fun testInvalidBackendOperation(code: ApiExceptionCode) {
+        val expectedMsg = "Invalid backend operation"
+        assertEquals(expectedMsg, code.msg, "Mismatch in message")
+    }
+
+    private fun testBioanalyzerServerError(code: ApiExceptionCode) {
+        val expectedMsg = "Bioanalyzer server error"
+        assertEquals(expectedMsg, code.msg, "Mismatch in message")
+    }
+
     /**
      * Tests ApiExceptionCode enum.
      */
     @Test
     fun testApiExceptionCodeEnum() {
         assertEquals(16, ApiExceptionCode.values().size, "ApiExceptionCode enum has ${ApiExceptionCode.values().size} values")
-
-        assertEquals("No citizen found for specified filters", ApiExceptionCode.NO_CITIZEN_FOUND.msg, "Mismatch in message")
-        assertEquals("Fingerprint did not match stored records for citizen supplied through filters", ApiExceptionCode.FINGERPRINT_NO_MATCH.msg, "Mismatch in message")
-        assertEquals("Given fingerprint is of too low quality to be used for matching. Please recapture", ApiExceptionCode.FINGERPRINT_LOW_QUALITY.msg, "Mismatch in message")
-        assertEquals("There is no fingerprint for supplied position stored in the database for matching citizen, it was not captured", ApiExceptionCode.FINGERPRINT_MISSING_NOT_CAPTURED.msg, "Mismatch in message")
-        assertEquals("There is no fingerprint stored in the database, due to amputation", ApiExceptionCode.FINGERPRINT_MISSING_AMPUTATION.msg, "Mismatch in message")
-        assertEquals("There is no fingerprint stored in the database, unable to record fingerprint", ApiExceptionCode.FINGERPRINT_MISSING_UNABLE_TO_PRINT.msg, "Mismatch in message")
-        assertEquals("One of your filters is invalid or missing", ApiExceptionCode.INVALID_FILTERS.msg, "Mismatch in message")
-        assertEquals("One of your params is invalid or missing", ApiExceptionCode.INVALID_PARAMS.msg, "Mismatch in message")
-        assertEquals("Invalid image encoding, must be base64 encoded", ApiExceptionCode.INVALID_IMAGE_ENCODING.msg, "Mismatch in message")
-        assertEquals("Invalid image format, must be one of ...", ApiExceptionCode.INVALID_IMAGE_FORMAT.msg, "Mismatch in message")
-        assertEquals("Invalid position, must be one of ...", ApiExceptionCode.INVALID_POSITION.msg, "Mismatch in message")
-        assertEquals("The data type is not supported for the backend", ApiExceptionCode.INVALID_DATA_TYPE.msg, "Mismatch in message")
-        assertEquals("Invalid template version", ApiExceptionCode.INVALID_TEMPLATE_VERSION.msg, "Mismatch in message")
-        assertEquals("Invalid backend name", ApiExceptionCode.INVALID_BACKEND_NAME.msg, "Invalid template version")
-        assertEquals("Invalid backend operation", ApiExceptionCode.INVALID_BACKEND_OPERATION.msg, "Mismatch in message")
-        assertEquals("Bioanalyzer server error", ApiExceptionCode.BIOANALYZER_SERVER_ERROR.msg, "Mismatch in message")
+        ApiExceptionCode.values().forEach {
+            when (it) {
+                ApiExceptionCode.NoCitizenFound -> testNoCitizenFound(it)
+                ApiExceptionCode.FingerprintNoMatch -> testFingerprintNoMatch(it)
+                ApiExceptionCode.FingerprintLowQuality -> testFingerprintLowQuality(it)
+                ApiExceptionCode.FingerprintMissingNotCaptured -> testFingerprintMissingNotCaptured(it)
+                ApiExceptionCode.FingerprintMissingAmputation -> testFingerprintMissingAmputation(it)
+                ApiExceptionCode.FingerprintMissingUnableToPrint -> testFingerprintMissingUnableToPrint(it)
+                ApiExceptionCode.InvalidFilters -> testInvalidFilters(it)
+                ApiExceptionCode.InvalidParams -> testInvalidParams(it)
+                ApiExceptionCode.InvalidImageEncoding -> testInvalidImageEncoding(it)
+                ApiExceptionCode.InvalidImageFormat -> testInvalidImageFormat(it)
+                ApiExceptionCode.InvalidPosition -> testInvalidPosition(it)
+                ApiExceptionCode.InvalidDataType -> testInvalidDataType(it)
+                ApiExceptionCode.InvalidTemplateVersion -> testInvalidTemplateVersion(it)
+                ApiExceptionCode.InvalidBackendName -> testInvalidBackendName(it)
+                ApiExceptionCode.InvalidBackendOperation -> testInvalidBackendOperation(it)
+                ApiExceptionCode.BioanalyzerServerError -> testBioanalyzerServerError(it)
+                else -> fail("No test defined for ApiExceptionCode ${it.name}")
+            }
+        }
     }
 }

--- a/identity_service/src/test/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/ApiExceptionTest.kt
+++ b/identity_service/src/test/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/ApiExceptionTest.kt
@@ -15,11 +15,11 @@ class ApiExceptionTest {
      */
     @Test
     fun testApiException() {
-        val ex = ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.NO_CITIZEN_FOUND, "error")
+        val ex = ApiException(HttpStatus.BAD_REQUEST, ApiExceptionCode.NoCitizenFound, "error")
         assertNotNull(ex, "Exception should not be null")
         assertEquals("400 BAD_REQUEST \"error\"", ex.message, "Exception message mismatch")
         assertEquals("error", ex.reason, "Exception reason mismatch")
         assertEquals(HttpStatus.BAD_REQUEST, ex.status, "Exception status mismatch")
-        assertEquals(ApiExceptionCode.NO_CITIZEN_FOUND, ex.code, "Exception code mismatch")
+        assertEquals(ApiExceptionCode.NoCitizenFound, ex.code, "Exception code mismatch")
     }
 }

--- a/identity_service/src/test/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/ValidationErrorTest.kt
+++ b/identity_service/src/test/kotlin/org/kiva/identityservice/errorhandling/exceptions/api/ValidationErrorTest.kt
@@ -15,12 +15,12 @@ class ValidationErrorTest {
      */
     @Test
     fun testValidationError() {
-        val ex = ValidationError(ApiExceptionCode.NO_CITIZEN_FOUND, "error")
+        val ex = ValidationError(ApiExceptionCode.NoCitizenFound, "error")
         assertNotNull(ex, "Exception should not be null")
         assertEquals("400 BAD_REQUEST \"error\"", ex.message, "Exception message mismatch")
         assertEquals("error", ex.reason, "Exception reason mismatch")
         assertEquals(HttpStatus.BAD_REQUEST, ex.status, "Exception status mismatch")
-        assertEquals(ApiExceptionCode.NO_CITIZEN_FOUND, ex.code, "Exception code mismatch")
+        assertEquals(ApiExceptionCode.NoCitizenFound, ex.code, "Exception code mismatch")
     }
 
     /**
@@ -28,11 +28,11 @@ class ValidationErrorTest {
      */
     @Test
     fun testValidationErrorNullReason() {
-        val ex = ValidationError(ApiExceptionCode.NO_CITIZEN_FOUND, null)
+        val ex = ValidationError(ApiExceptionCode.NoCitizenFound, null)
         assertNotNull(ex, "Exception should not be null")
         assertEquals("400 BAD_REQUEST \"No citizen found for specified filters\"", ex.message, "Exception message mismatch")
         assertEquals("No citizen found for specified filters", ex.reason, "Exception reason mismatch")
         assertEquals(HttpStatus.BAD_REQUEST, ex.status, "Exception status mismatch")
-        assertEquals(ApiExceptionCode.NO_CITIZEN_FOUND, ex.code, "Exception code mismatch")
+        assertEquals(ApiExceptionCode.NoCitizenFound, ex.code, "Exception code mismatch")
     }
 }


### PR DESCRIPTION
Everywhere else we use PascalCase for error codes. Identity Service should do that too.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>