### PR TITLE
PRO-3008: Fix Bio Auth Service integration failures

### DIFF
--- a/bio_auth_service/src/main/kotlin/common/utils/StringUtils.kt
+++ b/bio_auth_service/src/main/kotlin/common/utils/StringUtils.kt
@@ -1,17 +1,32 @@
 package org.kiva.bioauthservice.common.utils
 
+import org.apache.commons.codec.binary.Hex
 import java.util.Base64
 
 /**
- * Convert a base64 encoded String to a ByteArray
+ * Convert a Base64-encoded String to a ByteArray
  */
 fun String.base64ToByte(): ByteArray {
     return Base64.getDecoder().decode(this)
 }
 
 /**
- * Convert a base64 encoded ByteArray to a String
+ * Convert a ByteArray to a Base64-encoded String
  */
-fun ByteArray.base64ToString(): String {
+fun ByteArray.toBase64String(): String {
     return Base64.getEncoder().encodeToString(this)
+}
+
+/**
+ * Convert a Hex-encoded String to a ByteArray
+ */
+fun String.hexToByte(): ByteArray {
+    return Hex.decodeHex(this)
+}
+
+/**
+ * Convert a ByteArray to a Hex-encoded String
+ */
+fun ByteArray.toHexString(): String {
+    return Hex.encodeHexString(this)
 }

--- a/bio_auth_service/src/main/kotlin/db/DbRegistry.kt
+++ b/bio_auth_service/src/main/kotlin/db/DbRegistry.kt
@@ -18,8 +18,14 @@ fun Application.registerDB(appRegistry: AppRegistry): DbRegistry {
     // Set up Hikari connection pool
     val ds = HikariDataSource(dbConfig.hikariConfig())
 
-    // Set up Flyway
-    val flyway: Flyway = Flyway.configure().dataSource(ds).load()
+    // Set up Flyway (includes configuring it to set a baseline in case it migrates against an existing database - by default, V1)
+    val flyway = Flyway
+        .configure()
+        .baselineOnMigrate(true)
+        .dataSource(ds)
+        .load()
+
+    // If running on an empty db
     if (flyway.info().pending().isNotEmpty()) {
         logger.info("Starting to run migrations")
         flyway.migrate()

--- a/bio_auth_service/src/main/kotlin/fingerprint/dtos/VerifyRequestDto.kt
+++ b/bio_auth_service/src/main/kotlin/fingerprint/dtos/VerifyRequestDto.kt
@@ -10,7 +10,7 @@ data class VerifyRequestDto(
 
     /**
      * DEPRECATED
-     * Base64 representation of the fingerprint we should check
+     * Base64 or Hex representation of the fingerprint we should check
      */
     val image: String? = null,
 

--- a/bio_auth_service/src/test/kotlin/bioanalyzer/BioanalyzerServiceSpec.kt
+++ b/bio_auth_service/src/test/kotlin/bioanalyzer/BioanalyzerServiceSpec.kt
@@ -16,7 +16,7 @@ import org.kiva.bioauthservice.bioanalyzer.BioanalyzerService
 import org.kiva.bioauthservice.bioanalyzer.dtos.BioanalyzerReponseDto
 import org.kiva.bioauthservice.common.errors.impl.BioanalyzerServiceException
 import org.kiva.bioauthservice.common.errors.impl.FingerprintLowQualityException
-import org.kiva.bioauthservice.common.utils.base64ToString
+import org.kiva.bioauthservice.common.utils.toBase64String
 import org.slf4j.LoggerFactory
 
 @KtorExperimentalAPI
@@ -27,7 +27,7 @@ class BioanalyzerServiceSpec : StringSpec({
     val baseUrl = "http://bioanalyzer-service:8080"
     val analyzePath = "/api/v1/analyze"
     val bioanalyzerUrl = baseUrl + analyzePath
-    val image = this.javaClass.getResource("/images/sample.png")?.readBytes()?.base64ToString() ?: ""
+    val image = this.javaClass.getResource("/images/sample.png")?.readBytes()?.toBase64String() ?: ""
     val requestId = alphanumericStringGen.next()
 
     beforeEach {

--- a/bio_auth_service/src/test/kotlin/fingerprint/routes/FingerprintSaveRoutesSpec.kt
+++ b/bio_auth_service/src/test/kotlin/fingerprint/routes/FingerprintSaveRoutesSpec.kt
@@ -25,7 +25,7 @@ import org.kiva.bioauthservice.app.config.AppConfig
 import org.kiva.bioauthservice.bioanalyzer.dtos.BioanalyzerReponseDto
 import org.kiva.bioauthservice.common.errors.ApiError
 import org.kiva.bioauthservice.common.errors.BioAuthExceptionCode
-import org.kiva.bioauthservice.common.utils.base64ToString
+import org.kiva.bioauthservice.common.utils.toBase64String
 import org.kiva.bioauthservice.db.repositories.FingerprintTemplateRepository
 import org.kiva.bioauthservice.fingerprint.dtos.BulkSaveRequestDto
 import org.kiva.bioauthservice.fingerprint.dtos.SaveRequestDto
@@ -50,7 +50,7 @@ class FingerprintSaveRoutesSpec : WordSpec({
 
     // Test fixtures
     val template = this.javaClass.getResource("/images/sample_source_afis_template.txt")?.readText() ?: ""
-    val image = this.javaClass.getResource("/images/sample.png")?.readBytes()?.base64ToString() ?: ""
+    val image = this.javaClass.getResource("/images/sample.png")?.readBytes()?.toBase64String() ?: ""
     val appConfig = AppConfig(HoconApplicationConfig(ConfigFactory.load()))
     val bioanalyzerUrl = appConfig.bioanalyzerConfig.baseUrl + appConfig.bioanalyzerConfig.analyzePath
     val mockFingerprintTemplateRepository = mockk<FingerprintTemplateRepository>()

--- a/bio_auth_service/src/test/kotlin/fingerprint/routes/FingerprintVerifyRoutesSpec.kt
+++ b/bio_auth_service/src/test/kotlin/fingerprint/routes/FingerprintVerifyRoutesSpec.kt
@@ -25,7 +25,7 @@ import org.kiva.bioauthservice.bioanalyzer.dtos.BioanalyzerReponseDto
 import org.kiva.bioauthservice.common.errors.ApiError
 import org.kiva.bioauthservice.common.errors.BioAuthExceptionCode
 import org.kiva.bioauthservice.common.utils.base64ToByte
-import org.kiva.bioauthservice.common.utils.base64ToString
+import org.kiva.bioauthservice.common.utils.toBase64String
 import org.kiva.bioauthservice.db.daos.FingerprintTemplateDao
 import org.kiva.bioauthservice.db.daos.ReplayDao
 import org.kiva.bioauthservice.db.repositories.FingerprintTemplateRepository
@@ -52,8 +52,8 @@ class FingerprintVerifyRoutesSpec : WordSpec({
     val backend = alphanumericStringGen.next()
     val position = FingerPosition.RIGHT_INDEX
     val template = this.javaClass.getResource("/images/sample_source_afis_template.txt")?.readText() ?: ""
-    val image = this.javaClass.getResource("/images/sample.jpg")?.readBytes()?.base64ToString() ?: ""
-    val image2 = this.javaClass.getResource("/images/sample.png")?.readBytes()?.base64ToString() ?: "" // Not the same fingerprint
+    val image = this.javaClass.getResource("/images/sample.jpg")?.readBytes()?.toBase64String() ?: ""
+    val image2 = this.javaClass.getResource("/images/sample.png")?.readBytes()?.toBase64String() ?: "" // Not the same fingerprint
     val sourceAfisTemplate = FingerprintTemplate(template.base64ToByte())
     val appConfig = AppConfig(HoconApplicationConfig(ConfigFactory.load()))
     val bioanalyzerUrl = appConfig.bioanalyzerConfig.baseUrl + appConfig.bioanalyzerConfig.analyzePath


### PR DESCRIPTION
NOTE: https://github.com/kiva/protocol-aries/pull/145 & https://github.com/kiva/protocol/pull/870 depend on this PR. Cannot deploy BioAuthService until this goes out.

* There was an error thrown by Flyway (the migration management tool) when running migrations against an existing database with data in it already.
  * The fix is to set a "baseline" for Flyway to use if it's run against a non-empty database.
  * This works because the V1 migration was defined in such a way as it would recreate the existing database.
* It turns out that the citizen_biometrics database used in integration tests and by some controllers provides hex-encoded images instead of base64-encoded images.
  * The fix is to handle both hex-encoded and base64-encoded images in the Verify and Save DTO definitions.
  * Added tests to make sure this type of usage works

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>