### PR TITLE
Fix shape of error code

### DIFF
--- a/bio_auth_service/src/main/kotlin/common/errors/ApiError.kt
+++ b/bio_auth_service/src/main/kotlin/common/errors/ApiError.kt
@@ -13,5 +13,6 @@ data class ApiError(
     val path: String,
     val status: Int,
     val error: String,
+    val code: String,
     val message: String?
 )

--- a/bio_auth_service/src/main/kotlin/common/errors/BioAuthException.kt
+++ b/bio_auth_service/src/main/kotlin/common/errors/BioAuthException.kt
@@ -16,6 +16,6 @@ open class BioAuthException(
     @ExperimentalSerializationApi
     fun toApiResponseBody(uri: String): ApiError {
         val now = ZonedDateTime.now(Clock.systemUTC())
-        return ApiError(now, uri, status.value, code.name, reason)
+        return ApiError(now, uri, status.value, status.description, code.name, reason)
     }
 }

--- a/bio_auth_service/src/test/kotlin/fingerprint/routes/FingerprintSaveRoutesSpec.kt
+++ b/bio_auth_service/src/test/kotlin/fingerprint/routes/FingerprintSaveRoutesSpec.kt
@@ -177,7 +177,7 @@ class FingerprintSaveRoutesSpec : WordSpec({
                     response shouldHaveStatus HttpStatusCode.BadRequest
                     response.content shouldNotBe null
                     val responseBody = Json.decodeFromString(ApiError.serializer(), response.content!!)
-                    responseBody.error shouldBe BioAuthExceptionCode.BadRequestError.name
+                    responseBody.code shouldBe BioAuthExceptionCode.BadRequestError.name
                 }
             }
         }
@@ -200,7 +200,7 @@ class FingerprintSaveRoutesSpec : WordSpec({
                     response shouldHaveStatus HttpStatusCode.BadRequest
                     response.content shouldNotBe null
                     val responseBody = Json.decodeFromString(ApiError.serializer(), response.content!!)
-                    responseBody.error shouldBe BioAuthExceptionCode.BadRequestError.name
+                    responseBody.code shouldBe BioAuthExceptionCode.BadRequestError.name
                 }
             }
         }
@@ -225,7 +225,7 @@ class FingerprintSaveRoutesSpec : WordSpec({
                     response shouldHaveStatus HttpStatusCode.BadRequest
                     response.content shouldNotBe null
                     val responseBody = Json.decodeFromString(ApiError.serializer(), response.content!!)
-                    responseBody.error shouldBe BioAuthExceptionCode.BioanalyzerServerError.name
+                    responseBody.code shouldBe BioAuthExceptionCode.BioanalyzerServerError.name
                 }
             }
         }
@@ -334,7 +334,7 @@ class FingerprintSaveRoutesSpec : WordSpec({
                     response shouldHaveStatus HttpStatusCode.BadRequest
                     response.content shouldNotBe null
                     val responseBody = Json.decodeFromString(ApiError.serializer(), response.content!!)
-                    responseBody.error shouldBe BioAuthExceptionCode.BadRequestError.name
+                    responseBody.code shouldBe BioAuthExceptionCode.BadRequestError.name
                 }
             }
         }
@@ -360,7 +360,7 @@ class FingerprintSaveRoutesSpec : WordSpec({
                     response shouldHaveStatus HttpStatusCode.BadRequest
                     response.content shouldNotBe null
                     val responseBody = Json.decodeFromString(ApiError.serializer(), response.content!!)
-                    responseBody.error shouldBe BioAuthExceptionCode.BioanalyzerServerError.name
+                    responseBody.code shouldBe BioAuthExceptionCode.BioanalyzerServerError.name
                 }
             }
         }

--- a/bio_auth_service/src/test/kotlin/fingerprint/routes/FingerprintVerifyRoutesSpec.kt
+++ b/bio_auth_service/src/test/kotlin/fingerprint/routes/FingerprintVerifyRoutesSpec.kt
@@ -142,7 +142,7 @@ class FingerprintVerifyRoutesSpec : WordSpec({
                     response shouldHaveStatus HttpStatusCode.BadRequest
                     response.content shouldNotBe null
                     val responseBody = Json.decodeFromString(ApiError.serializer(), response.content!!)
-                    responseBody.error shouldBe BioAuthExceptionCode.FingerprintLowQuality.name
+                    responseBody.code shouldBe BioAuthExceptionCode.FingerprintLowQuality.name
                 }
             }
         }
@@ -161,7 +161,7 @@ class FingerprintVerifyRoutesSpec : WordSpec({
                     response shouldHaveStatus HttpStatusCode.BadRequest
                     response.content shouldNotBe null
                     val responseBody = Json.decodeFromString(ApiError.serializer(), response.content!!)
-                    responseBody.error shouldBe BioAuthExceptionCode.FingerprintNoMatch.name
+                    responseBody.code shouldBe BioAuthExceptionCode.FingerprintNoMatch.name
                 }
             }
         }
@@ -179,7 +179,7 @@ class FingerprintVerifyRoutesSpec : WordSpec({
                     response shouldHaveStatus HttpStatusCode.BadRequest
                     response.content shouldNotBe null
                     val responseBody = Json.decodeFromString(ApiError.serializer(), response.content!!)
-                    responseBody.error shouldBe BioAuthExceptionCode.FingerprintMissingAmputation.name
+                    responseBody.code shouldBe BioAuthExceptionCode.FingerprintMissingAmputation.name
                 }
             }
         }
@@ -197,7 +197,7 @@ class FingerprintVerifyRoutesSpec : WordSpec({
                     response shouldHaveStatus HttpStatusCode.BadRequest
                     response.content shouldNotBe null
                     val responseBody = Json.decodeFromString(ApiError.serializer(), response.content!!)
-                    responseBody.error shouldBe BioAuthExceptionCode.InvalidTemplateVersion.name
+                    responseBody.code shouldBe BioAuthExceptionCode.InvalidTemplateVersion.name
                 }
             }
         }


### PR DESCRIPTION
BioAuthService had slightly deviated from the expected error response shape, which was causing some undesired downstream errors. This PR addresses that deviation and updates local tests.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>