### PR TITLE
Remove dependency on JCenter and bintray

### DIFF
--- a/bio_auth_service/build.gradle
+++ b/bio_auth_service/build.gradle
@@ -10,12 +10,8 @@ group = 'org.kiva.bioauthservice'
 version = "1.0-SNAPSHOT"
 sourceCompatibility = '11'
 
-// TODO: jcenter and bintray are going to be shutdown Feb 2022. https://blog.gradle.org/jcenter-shutdown
 repositories {
-    jcenter()
     mavenCentral()
-    maven { url 'https://dl.bintray.com/kotlin/kotlinx' }
-    maven { url 'https://dl.bintray.com/kotlin/ktor' }
 }
 
 dependencies {

--- a/bioanalyzer_service/build.gradle
+++ b/bioanalyzer_service/build.gradle
@@ -14,7 +14,6 @@ repositories {
     mavenCentral()
     maven { url 'https://repo.spring.io/snapshot' }
     maven { url 'https://repo.spring.io/milestone' }
-    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
Resolves #45 

Update gradle build files to no longer use jcenter or bintray, instead relying just on maven central.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>